### PR TITLE
feat(role): add Ansible linting to build workflow

### DIFF
--- a/{{ cookiecutter.role_name }}/.github/workflows/build.yml.j2
+++ b/{{ cookiecutter.role_name }}/.github/workflows/build.yml.j2
@@ -27,41 +27,57 @@
 ##
 
 name: Build
-"on":
-  pull_request:
+on: # yamllint disable-line rule:truty
+  pull_request: {}
   push:
     branches:
       - master
 
-defaults:
-  run:
-    working-directory: "{{ cookiecutter.namespace }}.{{ cookiecutter.role_name }}"
-
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v2
-        with:
-          path: "{{ cookiecutter.namespace }}.{{ cookiecutter.role_name }}"
+  yamllint:
+    name: YAML Lint
+    runs-on: ubuntu-22.04
 
-      - name: Set up Python 3.
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
 
-      - name: Install test dependencies.
-        run: pip3 install yamllint
+      - name: Install test dependencies
+        run: pip3 install --requirement requirements.txt
 
-      - name: Lint code.
-        run: |
-          yamllint .
+      - name: Lint code
+        run: yamllint .
+
+  ansiblelint:
+    name: Ansible Lint
+    needs: yamllint
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install test dependencies
+        run: pip3 install --requirement requirements.txt
+
+      - name: Lint code
+        run: ansible-lint .
 
   molecule:
-    name: Molecule
+    name: Molecule Test
+    needs: ansiblelint
     runs-on: ubuntu-22.04
+
     strategy:
       max-parallel: 4
       matrix:
@@ -71,20 +87,18 @@ jobs:
           - ubuntu2204
 
     steps:
-      - name: Check out the codebase.
+      - name: Check out the codebase
         uses: actions/checkout@v2
-        with:
-          path: "{{ cookiecutter.namespace }}.{{ cookiecutter.role_name }}"
 
-      - name: Set up Python 3.
+      - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
 
-      - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] docker
+      - name: Install test dependencies
+        run: pip3 install --requirement requirements.txt
 
-      - name: Run Molecule tests.
+      - name: Run Molecule tests
         run: molecule test --scenario-name {% raw %}${{ matrix.molecule-scenario }}{% endraw %}
         env:
           PY_COLORS: "1"


### PR DESCRIPTION
* Make each job dependent on the previous one.
* Use specific Ubuntu version, the same as in development.
* Install Python packages from requirements.txt, so that the build environment matches development.
* Remove unnecessary (?) working-directory variable.
* Disable YAML lint rule for "on" keyword of GitHub Actions.

Resolves: #3